### PR TITLE
Test fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
 
+      - name: Run `zig build -Dminimal=true`
+        run: zig build -Dminimal --summary all
+
       - name: Run `zig build`
         run: zig build --summary all
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Run `zig build`
         run: zig build --summary all
+
+      - name: Run `zig build test`
+        run: zig build test --summary all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.14.1
 
       - name: Run `zig build -Dminimal=true`
         run: zig build -Dminimal --summary all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.0
 
       - name: Run `zig build -Dminimal=true`
         run: zig build -Dminimal --summary all

--- a/build.zig
+++ b/build.zig
@@ -215,7 +215,7 @@ pub fn build(b: *Build) !void {
         exe_test_step.dependOn(&exe_test_run.step);
     }
 
-    const libarchive_test_step = b.step("libarchive_test", "Run the libarchive tests.");
+    const libarchive_test_step = b.step("libarchive_test", "Run the tests for libarchive.");
     test_step.dependOn(libarchive_test_step);
     const libarchive_test_module = b.createModule(.{
         .target = target,
@@ -379,8 +379,8 @@ fn configB2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void
 fn configBzip2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
     if (b.option(bool, "enable-bzip2", "Build support for bzip2 through libbz2 (default=true)") orelse true) {
         config_h.addValues(.{
-            .HAVE_BZLIB_H = null,
-            .HAVE_LIBBZ2 = null,
+            .HAVE_BZLIB_H = true,
+            .HAVE_LIBBZ2 = true,
         });
         if (b.lazyDependency("bzip2", .{ .target = module.resolved_target.?, .optimize = module.optimize.? })) |bzip2| {
             module.linkLibrary(bzip2.artifact("bz2"));

--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,10 @@ pub fn build(b: *Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const linkage = b.option(std.builtin.LinkMode, "linkage", "Link mode") orelse .static;
+    const strip = b.option(bool, "strip", "Omit debug information");
+    const pic = b.option(bool, "pic", "Produce Position Independent Code");
+
     // Provide a helpful error message if a user tries to compile on an unsupported platform.
     switch (target.result.os.tag) {
         .linux => {},
@@ -41,6 +45,8 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+        .strip = strip,
+        .pic = pic,
     });
     libarchive_module.addConfigHeader(config_h);
     libarchive_module.addIncludePath(upstream.path(""));
@@ -72,7 +78,7 @@ pub fn build(b: *Build) void {
     const libarchive = b.addLibrary(.{
         .name = package_name,
         .root_module = libarchive_module,
-        .linkage = .static,
+        .linkage = linkage,
     });
     libarchive.installHeadersDirectory(upstream.path("libarchive"), "", .{
         .include_extensions = &.{
@@ -87,6 +93,8 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+        .strip = strip,
+        .pic = pic,
     });
     libarchive_fe_module.addCSourceFiles(.{
         .root = upstream.path("libarchive_fe"),
@@ -114,6 +122,8 @@ pub fn build(b: *Build) void {
             .target = target,
             .optimize = optimize,
             .link_libc = true,
+            .strip = strip,
+            .pic = pic,
         });
         exe_module.addConfigHeader(config_h);
         exe_module.addIncludePath(upstream.path(""));

--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,7 @@ pub fn build(b: *Build) void {
     const linkage = b.option(std.builtin.LinkMode, "linkage", "Link mode") orelse .static;
     const strip = b.option(bool, "strip", "Omit debug information");
     const pic = b.option(bool, "pic", "Produce Position Independent Code");
+    const sanitize_c = b.option(bool, "sanitize_c", "Enable C sanitizer") orelse false; // TODO: Switch to default true
 
     // Provide a helpful error message if a user tries to compile on an unsupported platform.
     switch (target.result.os.tag) {
@@ -47,6 +48,7 @@ pub fn build(b: *Build) void {
         .link_libc = true,
         .strip = strip,
         .pic = pic,
+        .sanitize_c = sanitize_c,
     });
     libarchive_module.addConfigHeader(config_h);
     libarchive_module.addIncludePath(upstream.path(""));
@@ -95,6 +97,7 @@ pub fn build(b: *Build) void {
         .link_libc = true,
         .strip = strip,
         .pic = pic,
+        .sanitize_c = sanitize_c,
     });
     libarchive_fe_module.addCSourceFiles(.{
         .root = upstream.path("libarchive_fe"),
@@ -124,6 +127,7 @@ pub fn build(b: *Build) void {
             .link_libc = true,
             .strip = strip,
             .pic = pic,
+            .sanitize_c = sanitize_c,
         });
         exe_module.addConfigHeader(config_h);
         exe_module.addIncludePath(upstream.path(""));
@@ -158,6 +162,9 @@ pub fn build(b: *Build) void {
             .target = target,
             .optimize = optimize,
             .link_libc = true,
+            .strip = strip,
+            .pic = pic,
+            .sanitize_c = sanitize_c,
         });
         test_module.addCSourceFiles(.{
             .root = upstream.path(mod_name),

--- a/build.zig
+++ b/build.zig
@@ -235,9 +235,10 @@ pub fn build(b: *Build) void {
         .name = "libarchive_test",
         .root_module = libarchive_test_module,
     });
-    //libarchive_test.step.dependOn(run_configure_step);
     const libarchive_test_run = b.addRunArtifact(libarchive_test);
     libarchive_test_run.setCwd(upstream.path(""));
+    libarchive_test_run.addArg("-v");
+    libarchive_test_run.addArg("-d");
     libarchive_test_step.dependOn(&libarchive_test_run.step);
 }
 

--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,8 @@ pub fn build(b: *Build) !void {
     const pic = b.option(bool, "pic", "Produce Position Independent Code");
     const sanitize_c = b.option(bool, "sanitize_c", "Enable C sanitizer") orelse false; // TODO: Switch to default true
 
+    const minimal = b.option(bool, "minimal", "Build minimal artifacts. Dependencies are all set to default=false. (default=false)") orelse false;
+
     // Provide a helpful error message if a user tries to compile on an unsupported platform.
     switch (target.result.os.tag) {
         .linux => {},
@@ -70,25 +72,25 @@ pub fn build(b: *Build) !void {
         .files = libarchive_src,
         .flags = flags,
     });
-    configAcl(b, config_h, libarchive_module);
-    configB2(b, config_h, libarchive_module);
-    configBzip2(b, config_h, libarchive_module);
-    configExpat(b, config_h, libarchive_module);
-    configIconv(b, config_h, libarchive_module);
-    configLz4(b, config_h, libarchive_module);
-    configLzma(b, config_h, libarchive_module);
-    configLzo2(b, config_h, libarchive_module);
-    configRegex(b, config_h, libarchive_module);
-    configXml2(b, config_h, libarchive_module);
-    configZlib(b, config_h, libarchive_module);
-    configZstd(b, config_h, libarchive_module);
+    configAcl(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configB2(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configBzip2(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configExpat(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configIconv(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configLz4(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configLzma(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configLzo2(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configRegex(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configXml2(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configZlib(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configZstd(b, config_h, libarchive_module, .{ .minimal = minimal });
 
     // TODO: The configure script does some specialized things for the crypto libraries.
     // For now, we'll just configure as normal, but we'll need to add special steps in the future.
-    configCng(b, config_h, libarchive_module);
-    configMbedTls(b, config_h, libarchive_module);
-    configNettle(b, config_h, libarchive_module);
-    configOpenSsl(b, config_h, libarchive_module);
+    configCng(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configMbedTls(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configNettle(b, config_h, libarchive_module, .{ .minimal = minimal });
+    configOpenSsl(b, config_h, libarchive_module, .{ .minimal = minimal });
 
     const libarchive = b.addLibrary(.{
         .name = package_name,
@@ -288,11 +290,16 @@ fn configXAttr(config_h: *Step.ConfigHeader) void {
     });
 }
 
-fn configAcl(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+const ConfigOptions = struct {
+    minimal: bool,
+};
+
+fn configAcl(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     // TODO:
-    // const enable_acl = b.option(bool, enable-acl, "Enable acl support (default=true)");
+    // const enable_acl = b.option(bool, enable-acl, "Enable acl support (default=true)") orelse !options.minimal;
     _ = b;
     _ = module;
+    _ = options;
     config_h.addValues(.{
         .ARCHIVE_ACL_DARWIN = null,
         .ARCHIVE_ACL_FREEBSD = null,
@@ -366,18 +373,19 @@ fn configAcl(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) voi
     });
 }
 
-fn configB2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+fn configB2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     // TODO: Add libb2 support.
     _ = b;
     _ = module;
+    _ = options;
     config_h.addValues(.{
         .HAVE_BLAKE2_H = null,
         .HAVE_LIBB2 = null,
     });
 }
 
-fn configBzip2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
-    if (b.option(bool, "enable-bzip2", "Build support for bzip2 through libbz2 (default=true)") orelse true) {
+fn configBzip2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
+    if (b.option(bool, "enable-bzip2", "Build support for bzip2 through libbz2 (default=true)") orelse !options.minimal) {
         config_h.addValues(.{
             .HAVE_BZLIB_H = true,
             .HAVE_LIBBZ2 = true,
@@ -393,19 +401,21 @@ fn configBzip2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) v
     }
 }
 
-fn configCng(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+fn configCng(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     // TODO: Add CNG library support
     _ = b;
     _ = module;
+    _ = options;
     config_h.addValues(.{
         .HAVE_BCRYPT_H = null,
     });
 }
 
-fn configMbedTls(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+fn configMbedTls(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     // TODO: Add mbedtls library support
     _ = b;
     _ = module;
+    _ = options;
     config_h.addValues(.{
         .HAVE_MBEDTLS_AES_H = null,
         .HAVE_MBEDTLS_MD_H = null,
@@ -420,21 +430,22 @@ fn configMbedTls(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module)
     });
 }
 
-fn configExpat(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+fn configExpat(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     // TODO: Add Expat library support.
     _ = b;
     _ = module;
+    _ = options;
     config_h.addValues(.{
         .HAVE_EXPAT_H = null,
         .HAVE_LIBEXPAT = null,
     });
 }
 
-fn configIconv(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+fn configIconv(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     config_h.addValues(.{
         .HAVE_LOCALE_CHARSET = null,
     });
-    if (b.option(bool, "enable-iconv", "Enable iconv support (default=true)") orelse true) {
+    if (b.option(bool, "enable-iconv", "Enable iconv support (default=true)") orelse !options.minimal) {
         const target = module.resolved_target.?;
         const optimize = module.optimize.?;
 
@@ -480,8 +491,8 @@ fn configIconv(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) v
     }
 }
 
-fn configLz4(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
-    if (b.option(bool, "enable-lz4", "Build support for lz4 through liblz4 (default=true)") orelse true) {
+fn configLz4(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
+    if (b.option(bool, "enable-lz4", "Build support for lz4 through liblz4 (default=true)") orelse !options.minimal) {
         config_h.addValues(.{
             .HAVE_LIBLZ4 = true,
             .HAVE_LZ4HC_H = true,
@@ -499,10 +510,11 @@ fn configLz4(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) voi
     }
 }
 
-fn configLzma(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+fn configLzma(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     // TODO: Add LZMA library
     _ = b;
     _ = module;
+    _ = options;
     config_h.addValues(.{
         .HAVE_LIBLZMA = null,
         .HAVE_LZMA_H = null,
@@ -510,10 +522,11 @@ fn configLzma(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) vo
     });
 }
 
-fn configLzo2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+fn configLzo2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     // TODO: Add LZO2 library
     _ = b;
     _ = module;
+    _ = options;
     config_h.addValues(.{
         .HAVE_LIBLZO2 = null,
         .HAVE_LZO_LZO1X_H = null,
@@ -521,10 +534,11 @@ fn configLzo2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) vo
     });
 }
 
-fn configNettle(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+fn configNettle(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     // TODO: Add Nettle library
     _ = b;
     _ = module;
+    _ = options;
     config_h.addValues(.{
         .ARCHIVE_CRYPTO_MD5_NETTLE = null,
         .ARCHIVE_CRYPTO_RMD160_NETTLE = null,
@@ -542,14 +556,13 @@ fn configNettle(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) 
     });
 }
 
-fn configOpenSsl(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
-
+fn configOpenSsl(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     // TODO: add support for OpenSSL libcrypto
     config_h.addValues(.{
         .HAVE_LIBCRYPTO = null,
     });
 
-    if (b.option(bool, "enable-openssl", "Build support for mtree and xar hashes through openssl (default=true)") orelse true) {
+    if (b.option(bool, "enable-openssl", "Build support for mtree and xar hashes through openssl (default=true)") orelse !options.minimal) {
         config_h.addValues(.{
             .HAVE_LIBCRYPTO = null,
             .HAVE_OPENSSL_EVP_H = true,
@@ -590,9 +603,10 @@ fn configOpenSsl(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module)
     });
 }
 
-fn configRegex(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
+fn configRegex(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
     _ = b;
     _ = module;
+    _ = options;
     // TODO: Configure regex expression support.
     config_h.addValues(.{
         .HAVE_REGEX_H = null,
@@ -608,8 +622,8 @@ fn configRegex(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) v
     });
 }
 
-fn configXml2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
-    if (b.option(bool, "enable-xml2", "Build support for xar through libxml2 (default=true)") orelse true) {
+fn configXml2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
+    if (b.option(bool, "enable-xml2", "Build support for xar through libxml2 (default=true)") orelse !options.minimal) {
         config_h.addValues(.{
             .HAVE_LIBXML2 = true,
             .HAVE_LIBXML_XMLREADER_H = true,
@@ -627,8 +641,8 @@ fn configXml2(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) vo
     }
 }
 
-fn configZlib(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
-    if (b.option(bool, "enable-zlib", "Build support for gzip through zlib (default=true)") orelse true) {
+fn configZlib(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
+    if (b.option(bool, "enable-zlib", "Build support for gzip through zlib (default=true)") orelse !options.minimal) {
         config_h.addValues(.{ .HAVE_ZLIB_H = true });
         if (b.lazyDependency("zlib", .{ .target = module.resolved_target.?, .optimize = module.optimize.? })) |zlib| {
             module.linkLibrary(zlib.artifact("z"));
@@ -638,8 +652,8 @@ fn configZlib(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) vo
     }
 }
 
-fn configZstd(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module) void {
-    if (b.option(bool, "enable-zstd", "Build support for zstd through libzstd (default=true)") orelse true) {
+fn configZstd(b: *Build, config_h: *Step.ConfigHeader, module: *Build.Module, options: ConfigOptions) void {
+    if (b.option(bool, "enable-zstd", "Build support for zstd through libzstd (default=true)") orelse !options.minimal) {
         config_h.addValues(.{
             .HAVE_LIBZSTD = true,
             .HAVE_ZSTD_H = true,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .libarchive,
     .version = "3.7.9",
     .fingerprint = 0x2cf9e53043e2c7c, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.14.1",
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
There were a few test regressions introduced in the latest PR. This PR reintroduces the `test` step to CI, but turns off the sanitizer by default (for now). Users can opt-in to the sanitizer, and when we've fixed/disabled the tests that trigger the sanitizer, it'll be enabled by default. This PR also adds the `minimal`, `linkage`, `strip`, and `pic` build options. Lastly, a few minor fixes.